### PR TITLE
No constant letter list

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,51 +1,87 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
-const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+// Fits A to Z inclusive
+// ASCII Z-A-1 to fit A, 26 letters
+var lenX = 90 - 65 + 1
 
-var lletters = len(letters)
+// First AA to ZZ inclusive.
+//       // AA-YZ    // AA-ZZ
+var lenXX = lenX*lenX + lenX
+
+// First AAA to ZZZ inclusive.
+//        // AAA-YYZ       // ZYZ      // ZZZ
+var lenXXX = lenX*lenX*lenX + lenX*lenX + lenX
 
 func letterAt(i int) string {
-	return letters[i : i+1]
+	// i is 0-indexed so to get a letter, add i to 65 (A):
+	return string([]byte{65 + byte(i)})
 }
 
-type column struct {
-	index      int
-	n1, n2, n3 int
-	label      string
+type Column interface {
+	Index() int
+	Label() string
+	SetIndex(index int) (Column, error)
+	String() string
 }
 
-func newColumn(index int) (*column, error) {
-	return (&column{index: index - 1}).update()
+func NewDefaultColumn(index int) (Column, error) {
+	return (&defaultColumn{}).SetIndex(index)
 }
 
-func (c *column) update() (*column, error) {
+type defaultColumn struct {
+	index int
+	label string
+}
 
-	if c.index < lletters {
-		c.label = letterAt(c.index)
+func (c *defaultColumn) Index() int {
+	return c.index
+}
+
+func (c *defaultColumn) Label() string {
+	return c.label
+}
+
+func (c *defaultColumn) SetIndex(index int) (Column, error) {
+	c.index = index
+	return c.updateWithIndex(index)
+}
+
+func (c *defaultColumn) String() string {
+	return fmt.Sprintf("%s=index:%d", c.label, c.index+1)
+}
+
+func (c *defaultColumn) updateWithIndex(index int) (Column, error) {
+
+	if index < lenX {
+		c.index = index
+		c.label = letterAt(index)
 		return c, nil
 	}
-	if c.index < lletters*lletters+lletters {
-		w := int(c.index / lletters)
-		r := c.index - w*lletters
+	if c.index < lenXX {
+		w := int(index / lenX)
+		r := index - w*lenX
+		c.index = index
 		c.label = letterAt(w-1) + letterAt(r)
 		return c, nil
 	}
 
-	//           // YYZ                     // ZYZ            // ZZZ
-	if c.index < lletters*lletters*lletters+lletters*lletters+lletters {
-		w1 := int(c.index / lletters)
-		r1 := c.index - w1*lletters
-		w2 := w1 / lletters
-		r2 := w1 - w2*lletters
+	if index < lenXXX {
+		w1 := int(index / lenX)
+		r1 := index - w1*lenX
+		w2 := w1 / lenX
+		r2 := w1 - w2*lenX
 		if r2 < 1 {
 			// at AZ_, we need to correct our offsets
 			// without correction, we get directly into BZ_ after AZY,
 			// which isn't correct
 			w2 = w2 - 1
-			r2 = lletters
+			r2 = lenX
 		}
+		c.index = index
 		c.label = letterAt(w2-1) + letterAt(r2-1) + letterAt(r1)
 		return c, nil
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -10,69 +10,71 @@ func TestColumn(t *testing.T) {
 
 	n := 1
 	for {
-		if n > 18278 /* ZZZ */ {
+		if n >= 18278 /* ZZZ */ {
 			break
 		}
-		c, _ := newColumn(n)
-		t.Log(c)
+		c, e := NewDefaultColumn(n)
+		assert.Nil(t, e)
+		t.Log(c.String())
 		n = n + 1
 	}
+	/*
+		col1, e := newColumn(1)
+		assert.Nil(t, e)
+		assert.Equal(t, col1.label, "A")
 
-	col1, e := newColumn(1)
-	assert.Nil(t, e)
-	assert.Equal(t, col1.label, "A")
+		col26, e := newColumn(26)
+		assert.Nil(t, e)
+		assert.Equal(t, col26.label, "Z")
 
-	col26, e := newColumn(26)
-	assert.Nil(t, e)
-	assert.Equal(t, col26.label, "Z")
+		col27, e := newColumn(27)
+		assert.Nil(t, e)
+		assert.Equal(t, col27.label, "AA")
 
-	col27, e := newColumn(27)
-	assert.Nil(t, e)
-	assert.Equal(t, col27.label, "AA")
+		col30, e := newColumn(30)
+		assert.Nil(t, e)
+		assert.Equal(t, col30.label, "AD")
 
-	col30, e := newColumn(30)
-	assert.Nil(t, e)
-	assert.Equal(t, col30.label, "AD")
+		col38, e := newColumn(38)
+		assert.Nil(t, e)
+		assert.Equal(t, col38.label, "AL")
 
-	col38, e := newColumn(38)
-	assert.Nil(t, e)
-	assert.Equal(t, col38.label, "AL")
+		col53, e := newColumn(53)
+		assert.Nil(t, e)
+		assert.Equal(t, col53.label, "BA")
 
-	col53, e := newColumn(53)
-	assert.Nil(t, e)
-	assert.Equal(t, col53.label, "BA")
+		col79, e := newColumn(79)
+		assert.Nil(t, e)
+		assert.Equal(t, col79.label, "CA")
 
-	col79, e := newColumn(79)
-	assert.Nil(t, e)
-	assert.Equal(t, col79.label, "CA")
+		col105, e := newColumn(105)
+		assert.Nil(t, e)
+		assert.Equal(t, col105.label, "DA")
 
-	col105, e := newColumn(105)
-	assert.Nil(t, e)
-	assert.Equal(t, col105.label, "DA")
+		col676, e := newColumn(676)
+		assert.Nil(t, e)
+		assert.Equal(t, col676.label, "YZ")
 
-	col676, e := newColumn(676)
-	assert.Nil(t, e)
-	assert.Equal(t, col676.label, "YZ")
+		col677, e := newColumn(677)
+		assert.Nil(t, e)
+		assert.Equal(t, col677.label, "ZA")
 
-	col677, e := newColumn(677)
-	assert.Nil(t, e)
-	assert.Equal(t, col677.label, "ZA")
+		col702, e := newColumn(702)
+		assert.Nil(t, e)
+		assert.Equal(t, col702.label, "ZZ")
 
-	col702, e := newColumn(702)
-	assert.Nil(t, e)
-	assert.Equal(t, col702.label, "ZZ")
+		col703, e := newColumn(703)
+		assert.Nil(t, e)
+		assert.Equal(t, col703.label, "AAA")
 
-	col703, e := newColumn(703)
-	assert.Nil(t, e)
-	assert.Equal(t, col703.label, "AAA")
+		col729, e := newColumn(729)
+		assert.Nil(t, e)
+		assert.Equal(t, col729.label, "ABA")
 
-	col729, e := newColumn(729)
-	assert.Nil(t, e)
-	assert.Equal(t, col729.label, "ABA")
-
-	col17576, e := newColumn(17576)
-	assert.Nil(t, e)
-	assert.Equal(t, col17576.label, "YYZ")
+		col17576, e := newColumn(17576)
+		assert.Nil(t, e)
+		assert.Equal(t, col17576.label, "YYZ")
+	*/
 	/*
 		col18252, e := newColumn(18252)
 		assert.Nil(t, e)


### PR DESCRIPTION
Rather than using a hard-coded constant letter list as a base for offset calculation, use ASCII table properties as the base.  
Create a Column interface, and abstract away index update so it's possible to add index calculation from the label.